### PR TITLE
Functionality expansion + gmapjs.html refactoring

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -307,6 +307,15 @@ def mapview():
         }]
     )
 
+    userposition = Map(
+        identifier="userposition",
+        varname="userposition",
+        lat=0,
+        lng=0,
+        zoom=14,
+        user_position=True
+    )
+
     return render_template(
         'example.html',
         mymap=mymap,
@@ -320,7 +329,8 @@ def mapview():
         movingmap=movingmap,
         movingmarkers=movingmarkers,
         collapsible=collapsible,
-        infoboxmap=infoboxmap
+        infoboxmap=infoboxmap,
+        userposition=userposition
     )
 
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -245,6 +245,7 @@ def mapview():
 
     infoboxmap = Map(
         identifier="infoboxmap",
+        varname="infoboxmap",
         zoom=12,
         lat=59.939012,
         lng=30.315707,
@@ -316,6 +317,76 @@ def mapview():
         user_position=True
     )
 
+    markedfigures = Map(
+        identifier="markedfigures",
+        varname='markedfigures',
+        zoom=12,
+        lat=59.939012,
+        lng=30.315707,
+        cluster=True,
+        cluster_maxzoom=10,
+        markers=[{
+            'lat': 59.939,
+            'lng': 30.315,
+            'infobox': 'This is a marker'
+        }],
+        circles=[{
+            'stroke_color': '#0000ff',
+            'stroke_opacity': 1.0,
+            'stroke_weight': 5,
+            'fill_color': '#0000ff',
+            'fill_opacity': 0.1,
+            'center': {
+                'lat': 59.948,
+                'lng': 30.315
+            },
+            'radius': 200,
+            'infobox': "Circle without marker_zoom option"
+        }, {
+            'stroke_color': '#FF00FF',
+            'stroke_opacity': 1.0,
+            'stroke_weight': 7,
+            'fill_color': '#FF00FF',
+            'fill_opacity': 0.2,
+            'center': {
+                'lat': 59.939,
+                'lng': 30.3
+            },
+            'radius': 200,
+            'marker_zoom': 14,
+            'infobox': "Circle with marker_zoom option"
+        }],
+        polygons=[{
+            'stroke_color': '#0AB0DE',
+            'stroke_opacity': 1.0,
+            'stroke_weight': 3,
+            'path': [
+                [59.94, 30.318],
+                [59.946, 30.325],
+                [59.946, 30.34],
+                [59.941, 30.35],
+                [59.938, 30.33]
+            ],
+            'marker_zoom': 13,
+            'infobox': 'This is a polygon'
+        }],
+        rectangles=[{
+            'stroke_color': '#00ff00',
+            'stroke_opacity': .8,
+            'stroke_weight': 5,
+            'fill_color': '#00ff00',
+            'fill_opacity': .4,
+            'bounds': {
+                'north': 59.935,
+                'south': 59.93,
+                'east': 30.325,
+                'west': 30.3,
+            },
+            'marker_zoom': 13,
+            'infobox': "This is a rectangle"
+        }]
+    )
+
     return render_template(
         'example.html',
         mymap=mymap,
@@ -330,7 +401,8 @@ def mapview():
         movingmarkers=movingmarkers,
         collapsible=collapsible,
         infoboxmap=infoboxmap,
-        userposition=userposition
+        userposition=userposition,
+        markedfigures=markedfigures,
     )
 
 

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -136,22 +136,24 @@ in body:
 {{movingmap.html}}
 
 {%  for position in movingmarkers %}
-<button onclick='movingmap_markers.map(function(mk){mk.setPosition({lat: {{ position.lat }}, lng:{{ position.lng }}})})'>Go to position {{ loop.index }} </button>
+<button onclick='{{ movingmap.varname }}.markers.map(function(mk){mk.setPosition({lat: {{ position.lat }}, lng:{{ position.lng }}})})'>Go to position {{ loop.index }} </button>
 {% endfor %}
 <br />
-<button onclick='movingmap_markers.map(function(mk){mk.setMap(null)})'>Remove marker</button>
-<button onclick='movingmap_markers.map(function(mk){mk.setMap(movingmap)})'>Restore marker</button>
-<button onclick='new google.maps.Marker({title: "New Marker", position: {lat: 37.4640, lng: -122.1350}}).setMap(movingmap)'>Add New Marker Above</button>
+<button onclick='{{ movingmap.varname }}.markers.map(function(mk){mk.setMap(null)})'>Remove marker</button>
+<button onclick='{{ movingmap.varname }}.markers.map(function(mk){mk.setMap({{ movingmap.varname }}.map)})'>Restore marker</button>
+<button onclick='new google.maps.Marker({title: "New Marker", position: {lat: 37.4640, lng: -122.1350}}).setMap({{ movingmap.varname }}.map)'>Add New Marker Above</button>
 
 
     <pre>
-&lt;button onclick='movingmap_markers.map(function(mk){mk.setPosition({lat: 37.44, lng:-122.135})})'&gt;Go to position 1 &lt;/button&gt;
-&lt;button onclick='movingmap_markers.map(function(mk){mk.setPosition({lat: 37.443, lng:-122.135})})'&gt;Go to position 2 &lt;/button&gt;
-&lt;button onclick='movingmap_markers.map(function(mk){mk.setPosition({lat: 37.445, lng:-122.135})})'&gt;Go to position 3 &lt;/button&gt;
-&lt;button onclick='movingmap_markers.map(function(mk){mk.setPosition({lat: 37.449, lng:-122.135})})'&gt;Go to position 4 &lt;/button&gt;
-&lt;button onclick='movingmap_markers.map(function(mk){mk.setMap(null)})'&gt;Remove marker&lt;/button&gt;
-&lt;button onclick='movingmap_markers.map(function(mk){mk.setMap(movingmap)})'&gt;Restore marker&lt;/button&gt;
-&lt;button onclick='onclick='new google.maps.Marker({title: "New Marker", position: {lat: 37.4640, lng: -122.1350}}).setMap(movingmap)''&gt;Add new marker above&lt;/button&gt;
+{% raw %}
+&lt;button onclick='{{ movingmap.varname }}.markers.map(function(mk){mk.setPosition({lat: 37.44, lng:-122.135})})'&gt;Go to position 1 &lt;/button&gt;
+&lt;button onclick='{{ movingmap.varname }}.markers.map(function(mk){mk.setPosition({lat: 37.443, lng:-122.135})})'&gt;Go to position 2 &lt;/button&gt;
+&lt;button onclick='{{ movingmap.varname }}.markers.map(function(mk){mk.setPosition({lat: 37.445, lng:-122.135})})'&gt;Go to position 3 &lt;/button&gt;
+&lt;button onclick='{{ movingmap.varname }}.markers.map(function(mk){mk.setPosition({lat: 37.449, lng:-122.135})})'&gt;Go to position 4 &lt;/button&gt;
+&lt;button onclick='{{ movingmap.varname }}.markers.map(function(mk){mk.setMap(null)})'&gt;Remove marker&lt;/button&gt;
+&lt;button onclick='{{ movingmap.varname }}.markers.map(function(mk){mk.setMap({{ movingmap.varname }}.map)})'&gt;Restore marker&lt;/button&gt;
+&lt;button onclick='onclick='new google.maps.Marker({title: "New Marker", position: {lat: 37.4640, lng: -122.1350}}).setMap({{ movingmap.varname }}.map)''&gt;Add new marker above&lt;/button&gt;
+{% endraw %}
     </pre>
 
 

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -17,6 +17,7 @@
             {{collapsible.js}}
             {{infoboxmap.js}}
             {{userposition.js}}
+            {{markedfigures.js}}
     </head>
     <body>
         <h1>Flask Google Maps Example</h1>
@@ -338,6 +339,10 @@ in body:
         {{ userposition.html }}
 
         <pre>Map(... ,user_position=True)</pre>
+
+        <h2>Marked figures</h2>
+
+        {{ markedfigures.html }}
 
     </body>
 </html>

--- a/examples/templates/example.html
+++ b/examples/templates/example.html
@@ -16,6 +16,7 @@
             {{pgonmap.js}}
             {{collapsible.js}}
             {{infoboxmap.js}}
+            {{userposition.js}}
     </head>
     <body>
         <h1>Flask Google Maps Example</h1>
@@ -332,6 +333,11 @@ in body:
 
         <h2>Infoboxes for map shapes</h2>
         {{infoboxmap.html}}
+
+        <h2>User position map</h2>
+        {{ userposition.html }}
+
+        <pre>Map(... ,user_position=True)</pre>
 
     </body>
 </html>

--- a/flask_googlemaps/__init__.py
+++ b/flask_googlemaps/__init__.py
@@ -31,6 +31,7 @@ class Map(object):
                  scroll_wheel=True,
                  fullscreen_control=True,
                  collapsible=False,
+                 user_position=False,
                  cluster=False,
                  cluster_imagepath=DEFAULT_CLUSTER_IMAGE_PATH,
                  cluster_gridsize=60,
@@ -61,6 +62,7 @@ class Map(object):
         self.scroll_wheel = scroll_wheel
         self.fullscreen_control = fullscreen_control
         self.collapsible = collapsible
+        self.user_position = user_position
 
         self.cluster = cluster
         self.cluster_imagepath = cluster_imagepath

--- a/flask_googlemaps/__init__.py
+++ b/flask_googlemaps/__init__.py
@@ -35,6 +35,7 @@ class Map(object):
                  cluster=False,
                  cluster_imagepath=DEFAULT_CLUSTER_IMAGE_PATH,
                  cluster_gridsize=60,
+                 cluster_maxzoom=20,
                  **kwargs):
         """Builds the Map properties"""
         self.cls = cls
@@ -67,6 +68,7 @@ class Map(object):
         self.cluster = cluster
         self.cluster_imagepath = cluster_imagepath
         self.cluster_gridsize = cluster_gridsize
+        self.cluster_maxzoom=cluster_maxzoom
 
     def build_markers(self, markers):
         if not markers:
@@ -186,6 +188,7 @@ class Map(object):
                              stroke_weight=2,
                              fill_color='#FF0000',
                              fill_opacity=.3,
+                             marker_zoom=None,
                              ):
         """ Set a dictionary with the javascript class Rectangle parameters
 
@@ -213,6 +216,7 @@ class Map(object):
             'stroke_weight': stroke_weight,
             'fill_color': fill_color,
             'fill_opacity': fill_opacity,
+            'marker_zoom': marker_zoom,
             'bounds': {'north': north,
                        'west': west,
                        'south': south,
@@ -326,6 +330,7 @@ class Map(object):
                           stroke_weight=2,
                           fill_color='#FF0000',
                           fill_opacity=.3,
+                          marker_zoom=None,
                           ):
         """ Set a dictionary with the javascript class Circle parameters
 
@@ -353,6 +358,7 @@ class Map(object):
             'stroke_weight': stroke_weight,
             'fill_color': fill_color,
             'fill_opacity': fill_opacity,
+            'marker_zoom': marker_zoom,
             'center': {'lat': center_lat,
                        'lng': center_lng},
             'radius': radius,
@@ -612,7 +618,8 @@ class Map(object):
                            stroke_opacity=.8,
                            stroke_weight=2,
                            fill_color='#FF0000',
-                           fill_opacity=0.3):
+                           fill_opacity=0.3,
+                           marker_zoom=None):
         """ Set a dictionary with the javascript class Polygon parameters
 
         This function sets a default drawing configuration if the user just
@@ -642,7 +649,8 @@ class Map(object):
             'stroke_opacity': stroke_opacity,
             'stroke_weight': stroke_weight,
             'fill_color': fill_color,
-            'fill_opacity': fill_opacity
+            'fill_opacity': fill_opacity,
+            'marker_zoom': marker_zoom,
         }
 
         return polygon
@@ -718,7 +726,9 @@ class Map(object):
             'cluster': self.cluster,
             'cluster_imagepath': self.cluster_imagepath,
             'cluster_gridsize': self.cluster_gridsize,
+            'cluster_maxzoom': self.cluster_maxzoom,
             'collapsible': self.collapsible,
+            'user_position': self.user_position,
             'js': dumps(self.js),
             'html': dumps(self.html),
         }

--- a/flask_googlemaps/templates/googlemaps/gmapjs.html
+++ b/flask_googlemaps/templates/googlemaps/gmapjs.html
@@ -330,15 +330,7 @@
                 }
             }
         };
-        if (typeof window.onload === 'function') {
-            func = window.onload;
-            window.onload = function() {
-                func();
-                init_{{gmap.identifier}}_button();
-            }
-        } else {
-            window.onload = init_{{gmap.identifier}}_button;
-        }
+        window.addEventListener('load', init_{{gmap.identifier}}_button);
     {% else %}
         google.maps.event.addDomListener(window, 'load', {{gmap.varname}}.initialize);
     {% endif %}

--- a/flask_googlemaps/templates/googlemaps/gmapjs.html
+++ b/flask_googlemaps/templates/googlemaps/gmapjs.html
@@ -129,6 +129,9 @@
         <script src="//cdnjs.cloudflare.com/ajax/libs/js-marker-clusterer/1.0.0/markerclusterer_compiled.js" type="text/javascript"></script>
 {%  endif %}
 
+{% if gmap.user_position %}
+    <script src="https://github.com/ChadKillingsworth/geolocation-marker/releases/download/v2.0.4/geolocation-marker.js"></script>
+{% endif %}
 
 <style type="text/css">
       #{{gmap.identifier}} { {{gmap.style}} }
@@ -159,6 +162,18 @@
             rotateControl: {% if gmap.rotate_control %}true{% else %}false{% endif %},
             fullscreenControl: {% if gmap.fullscreen_control %}true{% else %}false{% endif %}
         });
+
+        {% if gmap.user_position %}
+            {{gmap.varname}}.geo_marker = new GeolocationMarker({{gmap.varname}}.map);
+            {{gmap.varname}}.interval_id = setInterval(function() {
+                if ({{gmap.varname}}.geo_marker.getPosition() !== null) {
+                    {{gmap.varname}}.map.setCenter({{gmap.varname}}.geo_marker.getPosition());
+                    {{gmap.varname}}.map.setZoom({{gmap.zoom}});
+                    clearInterval({{gmap.varname}}.interval_id);
+                    delete {{gmap.varname}}.interval_id;
+                }
+            }, 1000);
+        {% endif %}
 
         {% if gmap.cluster %}
             {{gmap.varname}}.markerCluster = new MarkerClusterer({{gmap.varname}}.map, {{gmap.varname}}.markers, {'imagePath': "{{gmap.cluster_imagepath}}", 'gridSize': {{gmap.cluster_gridsize}}});

--- a/flask_googlemaps/templates/googlemaps/gmapjs.html
+++ b/flask_googlemaps/templates/googlemaps/gmapjs.html
@@ -5,6 +5,123 @@
     {%  else %}
         <script src="//maps.googleapis.com/maps/api/js" type="text/javascript"></script>
     {%  endif %}
+    <script type="text/javascript">
+        function add_marker(map_struct, new_marker) {
+            var marker = new google.maps.Marker({
+                position: new google.maps.LatLng(new_marker.lat, new_marker.lng),
+                map: map_struct.map,
+                icon: new_marker.icon,
+                title: new_marker.title ? new_marker.title : null
+            });
+            if(new_marker.infobox) {
+                google.maps.event.addListener(
+                    marker,
+                    'click',
+                    getInfoCallback(map_struct, new_marker.infobox)
+                );
+            }
+            if (map_struct.markerCluster) {
+                map_struct.markerCluster.addMarker(marker);
+            }
+            map_struct.markers.push(marker);
+        }
+        function add_rectangle(map_struct, new_rectangle) {
+            var rectangle = new google.maps.Rectangle({
+                strokeColor: new_rectangle.stroke_color,
+                strokeOpacity: new_rectangle.stroke_opacity,
+                strokeWeight: new_rectangle.stroke_weight,
+                fillColor: new_rectangle.fill_color,
+                fillOpacity: new_rectangle.fill_opacity,
+                map: map_struct.map,
+                bounds: {
+                    north: new_rectangle.bounds.north,
+                    east: new_rectangle.bounds.east,
+                    south: new_rectangle.bounds.south,
+                    west: new_rectangle.bounds.west },
+            });
+            if(new_rectangle.infobox) {
+                google.maps.event.addListener(
+                    rectangle,
+                    'click',
+                    getInfoCallback(map_struct, new_rectangle.infobox)
+                );
+            }
+            map_struct.rectangles.push(rectangle);
+        }
+        function add_circle(map_struct, new_circle) {
+            var circle = new google.maps.Circle({
+                strokeColor: new_circle.stroke_color,
+                strokeOpacity: new_circle.stroke_opacity,
+                strokeWeight: new_circle.stroke_weight,
+                fillColor: new_circle.fill_color,
+                fillOpacity: new_circle.fill_opacity,
+                map: map_struct.map,
+                center: {
+                    lat: new_circle.center.lat,
+                    lng: new_circle.center.lng,
+                },
+                radius: new_circle.radius
+            });
+            if(new_circle.infobox) {
+                google.maps.event.addListener(
+                    circle,
+                    'click',
+                    getInfoCallback(map_struct, new_circle.infobox)
+                );
+            }
+            map_struct.circles.push(circle);
+        }
+        function add_polygon(map_struct, new_polygon) {
+            var polygon = new google.maps.Polygon({
+                strokeColor: new_polygon.stroke_color,
+                strokeOpacity: new_polygon.stroke_opacity,
+                strokeWeight: new_polygon.stroke_weight,
+                fillOpacity: new_polygon.fill_opacity,
+                fillColor: new_polygon.fill_color,
+                path: new_polygon.path,
+                map: map_struct.map,
+                geodesic: true
+            });
+            if(new_polygon.infobox) {
+                google.maps.event.addListener(
+                    polygon,
+                    'click',
+                    getInfoCallback(map_struct, new_polygon.infobox)
+                );
+            }
+            map_struct.polygons.push(polygon);
+        }
+        function add_polyline(map_struct, new_polyline) {
+            var polyline = new google.maps.Polyline({
+                strokeColor: new_polyline.stroke_color,
+                strokeOpacity: new_polyline.stroke_opacity,
+                strokeWeight: new_polyline.stroke_weight,
+                path: new_polyline.path,
+                map: map_struct.map,
+                geodesic: true
+            });
+            if(new_polyline.infobox) {
+                google.maps.event.addListener(
+                    polyline,
+                    'click',
+                    getInfoCallback(map_struct, new_polyline.infobox)
+                );
+            }
+            map_struct.polylines.push(polyline);
+        }
+        function getInfoCallback(map_struct, content) {
+            var infowindow = new google.maps.InfoWindow({content: content});
+            //infowindow.setContent(content);
+            return function(ev) {
+                if (map_struct.prev_infowindow) {
+                    map_struct.prev_infowindow.close();
+                }
+                map_struct.prev_infowindow = infowindow;
+                infowindow.setPosition(ev.latLng);
+                infowindow.open(map_struct.map, this);
+            };
+        }
+    </script>
     {{ set_googlemaps_loaded() }}
 {% endif %}
 
@@ -18,18 +135,20 @@
 </style>
 
 <script type="text/javascript">
-    var {{gmap.varname}} = null;
-    var {{gmap.varname}}_markers = [];
-    var {{gmap.varname}}_rectangles = [];
-    var {{gmap.varname}}_circles = [];
-    var {{gmap.varname}}_polygons = [];
-    var {{gmap.varname}}_polylines = [];
-    var prev_infowindow_{{gmap.varname}} = null;
+    var {{gmap.varname}} = {};
 
-    function initialize_{{gmap.varname}}() {
+    {{gmap.varname}}.map = null;
+    {{gmap.varname}}.id = "{{gmap.identifier}}";
+    {{gmap.varname}}.markers = [];
+    {{gmap.varname}}.rectangles = [];
+    {{gmap.varname}}.circles = [];
+    {{gmap.varname}}.polygons = [];
+    {{gmap.varname}}.polylines = [];
+
+    {{gmap.varname}}.initialize = function() {
         document.getElementById('{{gmap.identifier}}').style.display = 'block';
-        {{gmap.varname}} = new google.maps.Map(
-        document.getElementById('{{gmap.identifier}}'), {
+        {{gmap.varname}}.map = new google.maps.Map(
+            document.getElementById('{{gmap.identifier}}'), {
             center: new google.maps.LatLng({{gmap.center.0}}, {{gmap.center.1}}),
             zoom: {{gmap.zoom}},
             mapTypeId: google.maps.MapTypeId.{{gmap.maptype}},
@@ -38,154 +157,45 @@
             scaleControl: {% if gmap.scale_control %}true{% else %}false{% endif %},
             streetViewControl: {% if gmap.streetview_control %}true{% else %}false{% endif %},
             rotateControl: {% if gmap.rotate_control %}true{% else %}false{% endif %},
-            scrollwheel: {% if gmap.scroll_wheel %}true{% else %}false{% endif %},
             fullscreenControl: {% if gmap.fullscreen_control %}true{% else %}false{% endif %}
         });
 
-        // add gmap markers
-        var raw_markers = {{gmap.markers|tojson|safe}};
-        for(i=0; i<{{gmap.markers|length}};i++) {
-            {{gmap.varname}}_markers[i] = new google.maps.Marker({
-                position: new google.maps.LatLng(raw_markers[i].lat, raw_markers[i].lng),
-                map: {{gmap.varname}},
-                icon: raw_markers[i].icon,
-                title: raw_markers[i].title ? raw_markers[i].title : null
-            });
+        {% if gmap.cluster %}
+            {{gmap.varname}}.markerCluster = new MarkerClusterer({{gmap.varname}}.map, {{gmap.varname}}.markers, {'imagePath': "{{gmap.cluster_imagepath}}", 'gridSize': {{gmap.cluster_gridsize}}});
+        {% endif %}
 
-           if(raw_markers[i].infobox)
-           {
-                google.maps.event.addListener(
-                        {{gmap.varname}}_markers[i],
-                        'click',
-                        getInfoCallback({{gmap.varname}}, raw_markers[i].infobox)
-                );
-           }
-        }
+        // add gmap markers
+        {{ gmap.markers|tojson|safe }}.forEach(function(el) {
+            add_marker({{gmap.varname}}, el);
+        });
 
         // add rectangles
-        var raw_rectangles = {{ gmap.rectangles|tojson|safe }};
-        for(i = 0; i < {{ gmap.rectangles|length }}; i++) {
-            {{ gmap.varname }}_rectangles[i] = new google.maps.Rectangle({
-                strokeColor: raw_rectangles[i].stroke_color,
-                strokeOpacity: raw_rectangles[i].stroke_opacity,
-                strokeWeight: raw_rectangles[i].stroke_weight,
-                fillColor: raw_rectangles[i].fill_color,
-                fillOpacity: raw_rectangles[i].fill_opacity,
-                map: {{gmap.varname}},
-                bounds: {
-                    north: raw_rectangles[i].bounds.north,
-                    east: raw_rectangles[i].bounds.east,
-                    south: raw_rectangles[i].bounds.south,
-                    west: raw_rectangles[i].bounds.west },
-            });
-
-           if(raw_rectangles[i].infobox)
-           {
-                google.maps.event.addListener(
-                        {{gmap.varname}}_rectangles[i],
-                        'click',
-                        getInfoCallback({{gmap.varname}}, raw_rectangles[i].infobox)
-                );
-           }
-        }
+        {{ gmap.rectangles|tojson|safe }}.forEach(function(el) {
+            add_rectangle({{gmap.varname}}, el);
+        });
 
         // add circles
-        var raw_circles = {{ gmap.circles|tojson|safe }};
-        for(i = 0; i < {{ gmap.circles|length }}; i++) {
-            {{ gmap.varname }}_circles[i] = new google.maps.Circle({
-                strokeColor: raw_circles[i].stroke_color,
-                strokeOpacity: raw_circles[i].stroke_opacity,
-                strokeWeight: raw_circles[i].stroke_weight,
-                fillColor: raw_circles[i].fill_color,
-                fillOpacity: raw_circles[i].fill_opacity,
-                map: {{gmap.varname}},
-                center: {
-                    lat: raw_circles[i].center.lat,
-                    lng: raw_circles[i].center.lng,
-                },
-                radius: raw_circles[i].radius
-            });
-
-           if(raw_circles[i].infobox)
-           {
-                google.maps.event.addListener(
-                        {{gmap.varname}}_circles[i],
-                        'click',
-                        getInfoCallback({{gmap.varname}}, raw_circles[i].infobox)
-                );
-           }
-        }
+        {{ gmap.circles|tojson|safe }}.forEach(function(el) {
+            add_circle({{gmap.varname}}, el);
+        });
 
         // add polygons
-        var raw_polygons = {{ gmap.polygons|tojson|safe }};
-        for(i = 0; i < {{ gmap.polygons|length }}; i++) {
-            {{ gmap.varname }}_polygons[i] = new google.maps.Polygon({
-                strokeColor: raw_polygons[i].stroke_color,
-                strokeOpacity: raw_polygons[i].stroke_opacity,
-                strokeWeight: raw_polygons[i].stroke_weight,
-                fillOpacity: raw_polygons[i].fill_opacity,
-                fillColor: raw_polygons[i].fill_color,
-                path: raw_polygons[i].path,
-                map: {{gmap.varname}},
-                geodesic: true
-            });
+        {{ gmap.polygons|tojson|safe }}.forEach(function(el) {
+            add_polygon({{gmap.varname}}, el);
+        });
 
-           if(raw_polygons[i].infobox)
-           {
-                google.maps.event.addListener(
-                        {{gmap.varname}}_polygons[i],
-                        'click',
-                        getInfoCallback({{gmap.varname}}, raw_polygons[i].infobox)
-                );
-           }
-        }
-    
         // add polylines
-        var raw_polylines = {{ gmap.polylines|tojson|safe }};
-        for(i = 0; i < {{ gmap.polylines|length }}; i++) {
-            {{ gmap.varname }}_polylines[i] = new google.maps.Polyline({
-                strokeColor: raw_polylines[i].stroke_color,
-                strokeOpacity: raw_polylines[i].stroke_opacity,
-                strokeWeight: raw_polylines[i].stroke_weight,
-                path: raw_polylines[i].path,
-                map: {{gmap.varname}},
-                geodesic: true
-            });
-
-           if(raw_polylines[i].infobox)
-           {
-                google.maps.event.addListener(
-                        {{gmap.varname}}_polylines[i],
-                        'click',
-                        getInfoCallback({{gmap.varname}}, raw_polylines[i].infobox)
-                );
-           }
-        }
-
-        {% if gmap.cluster %}
-    	    var markerCluster = new MarkerClusterer({{gmap.varname}}, {{gmap.varname}}_markers, {'imagePath': "{{gmap.cluster_imagepath}}", 'gridSize': {{gmap.cluster_gridsize}}});
-        {% endif %}
-    }
-
-    function getInfoCallback(map, content) {
-        var infowindow = new google.maps.InfoWindow({content: content});
-        return function(ev) {
-            if( prev_infowindow_{{gmap.varname}} ) {
-                prev_infowindow_{{gmap.varname}}.close();
-            }
-            prev_infowindow_{{gmap.varname}} = infowindow;
-            infowindow.setPosition(ev.latLng);
-            infowindow.setContent(content);
-            infowindow.open(map, this);
-        };
+        {{ gmap.polylines|tojson|safe }}.forEach(function(el) {
+            add_polyline({{gmap.varname}}, el);
+        });
     }
     
     {% if gmap.collapsible %}
         function init_{{gmap.identifier}}_button() {
             document.getElementById('{{gmap.identifier}}').style.display = 'none';
             document.getElementById('{{gmap.varname}}_collapse').onclick = function() {
-            if ({{gmap.varname}} === null) {
-                    initialize_{{gmap.varname}}();
+            if ({{gmap.varname}}.map === null) {
+                    {{gmap.varname}}.initialize();
                     document.getElementById('{{gmap.varname}}_collapse').textContent = "Hide map";
                 } else {
                     var m = document.getElementById('{{gmap.identifier}}');
@@ -199,7 +209,6 @@
                 }
             }
         };
-
         if (typeof window.onload === 'function') {
             func = window.onload;
             window.onload = function() {
@@ -210,7 +219,7 @@
             window.onload = init_{{gmap.identifier}}_button;
         }
     {% else %}
-        google.maps.event.addDomListener(window, 'load', initialize_{{gmap.varname}});
+        google.maps.event.addDomListener(window, 'load', {{gmap.varname}}.initialize);
     {% endif %}
 
 </script>

--- a/flask_googlemaps/templates/googlemaps/gmapjs.html
+++ b/flask_googlemaps/templates/googlemaps/gmapjs.html
@@ -6,7 +6,7 @@
         <script src="//maps.googleapis.com/maps/api/js" type="text/javascript"></script>
     {%  endif %}
     <script type="text/javascript">
-        function add_marker(map_struct, new_marker) {
+        function addMarker(map_struct, new_marker) {
             var marker = new google.maps.Marker({
                 position: new google.maps.LatLng(new_marker.lat, new_marker.lng),
                 map: map_struct.map,
@@ -25,7 +25,7 @@
             }
             map_struct.markers.push(marker);
         }
-        function add_rectangle(map_struct, new_rectangle) {
+        function addRectangle(map_struct, new_rectangle) {
             var rectangle = new google.maps.Rectangle({
                 strokeColor: new_rectangle.stroke_color,
                 strokeOpacity: new_rectangle.stroke_opacity,
@@ -38,6 +38,7 @@
                     east: new_rectangle.bounds.east,
                     south: new_rectangle.bounds.south,
                     west: new_rectangle.bounds.west },
+                visible: !new_rectangle.marker_zoom || map_struct.map.getZoom() >= new_rectangle.marker_zoom
             });
             if(new_rectangle.infobox) {
                 google.maps.event.addListener(
@@ -46,9 +47,44 @@
                     getInfoCallback(map_struct, new_rectangle.infobox)
                 );
             }
+            var callback;
+            if(new_rectangle.infobox) {
+                callback = getInfoCallback(map_struct, new_rectangle.infobox);
+                google.maps.event.addListener(
+                    rectangle,
+                    'click',
+                    callback
+                );
+            }
+            if (new_rectangle.marker_zoom) {
+                var position = new google.maps.LatLng(
+                    (new_rectangle.bounds.north + new_rectangle.bounds.south) / 2,
+                    (new_rectangle.bounds.east + new_rectangle.bounds.west) / 2
+                );
+                var rectangle_marker = new google.maps.Marker({
+                    position: position,
+                    map: map_struct.map,
+                    icon: "http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2|" + new_rectangle.fill_color.substring(1, new_rectangle.fill_color.length),
+                    visible: map_struct.map.getZoom() < new_rectangle.marker_zoom
+                });
+                if (callback) {
+                    google.maps.event.addListener(
+                        rectangle_marker,
+                        'click',
+                        function(ev) {
+                            callback(ev, rectangle);
+                            if (map_struct.map.getZoom() < new_rectangle.marker_zoom) map_struct.map.setZoom(new_rectangle.marker_zoom);
+                            map_struct.map.setCenter(position);
+                        }
+                    );
+                }
+                if (map_struct.marked_figures === undefined) initFigureMarking(map_struct);
+                map_struct.marked_figures.push({figure: rectangle, marker: rectangle_marker, zoom: new_rectangle.marker_zoom});
+                if (map_struct.markerCluster) map_struct.markerCluster.addMarker(rectangle_marker);
+            }
             map_struct.rectangles.push(rectangle);
         }
-        function add_circle(map_struct, new_circle) {
+        function addCircle(map_struct, new_circle) {
             var circle = new google.maps.Circle({
                 strokeColor: new_circle.stroke_color,
                 strokeOpacity: new_circle.stroke_opacity,
@@ -62,16 +98,42 @@
                 },
                 radius: new_circle.radius
             });
+            var callback;
             if(new_circle.infobox) {
+                callback = getInfoCallback(map_struct, new_circle.infobox);
                 google.maps.event.addListener(
                     circle,
                     'click',
-                    getInfoCallback(map_struct, new_circle.infobox)
+                    callback
                 );
+            }
+            if (new_circle.marker_zoom) {
+                var position = new google.maps.LatLng(new_circle.center.lat, new_circle.center.lng);
+                var circle_marker = new google.maps.Marker({
+                    position: position,
+                    map: map_struct.map,
+                    icon: "http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2|" + new_circle.fill_color.substring(1, new_circle.fill_color.length),
+                    visible: map_struct.map.getZoom() < new_circle.marker_zoom
+                });
+                if (callback) {
+                    google.maps.event.addListener(
+                        circle_marker,
+                        'click',
+                        function(ev) {
+                            callback(ev, circle);
+                            if (map_struct.map.getZoom() < new_circle.marker_zoom) map_struct.map.setZoom(new_circle.marker_zoom);
+                            map_struct.map.setCenter(position);
+                        }
+                    );
+                }
+                circle.setVisible(map_struct.map.getZoom() >= new_circle.marker_zoom);
+                if (map_struct.marked_figures === undefined) initFigureMarking(map_struct);
+                map_struct.marked_figures.push({figure: circle, marker: circle_marker, zoom: new_circle.marker_zoom});
+                if (map_struct.markerCluster) map_struct.markerCluster.addMarker(circle_marker);
             }
             map_struct.circles.push(circle);
         }
-        function add_polygon(map_struct, new_polygon) {
+        function addPolygon(map_struct, new_polygon) {
             var polygon = new google.maps.Polygon({
                 strokeColor: new_polygon.stroke_color,
                 strokeOpacity: new_polygon.stroke_opacity,
@@ -80,25 +142,54 @@
                 fillColor: new_polygon.fill_color,
                 path: new_polygon.path,
                 map: map_struct.map,
-                geodesic: true
+                geodesic: true,
+                visible: !new_polygon.marker_zoom || map_struct.map.getZoom() >= new_polygon.marker_zoom
             });
+            var callback;
             if(new_polygon.infobox) {
+                callback = getInfoCallback(map_struct, new_polygon.infobox);
                 google.maps.event.addListener(
                     polygon,
                     'click',
-                    getInfoCallback(map_struct, new_polygon.infobox)
+                    callback
                 );
+            }
+            if (new_polygon.marker_zoom) {
+                var path_sum = new_polygon.path.reduce(function(prev, cur) {
+                    return {lat: prev.lat + cur.lat, lng: prev.lng + cur.lng};
+                });
+                var position = new google.maps.LatLng(path_sum.lat / new_polygon.path.length, path_sum.lng / new_polygon.path.length);
+                var polygon_marker = new google.maps.Marker({
+                    position: position,
+                    map: map_struct.map,
+                    icon: "http://chart.apis.google.com/chart?chst=d_map_pin_letter&chld=%E2%80%A2|" + new_polygon.fill_color.substring(1, new_polygon.fill_color.length),
+                    visible: map_struct.map.getZoom() < new_polygon.marker_zoom
+                });
+                if (callback) {
+                    google.maps.event.addListener(
+                        polygon_marker,
+                        'click',
+                        function(ev) {
+                            callback(ev, polygon);
+                            if (map_struct.map.getZoom() < new_polygon.marker_zoom) map_struct.map.setZoom(new_polygon.marker_zoom);
+                            map_struct.map.setCenter(position);
+                        }
+                    );
+                }
+                if (map_struct.marked_figures === undefined) initFigureMarking(map_struct);
+                map_struct.marked_figures.push({figure: polygon, marker: polygon_marker, zoom: new_polygon.marker_zoom});
+                if (map_struct.markerCluster) map_struct.markerCluster.addMarker(polygon_marker);
             }
             map_struct.polygons.push(polygon);
         }
-        function add_polyline(map_struct, new_polyline) {
+        function addPolyline(map_struct, new_polyline) {
             var polyline = new google.maps.Polyline({
                 strokeColor: new_polyline.stroke_color,
                 strokeOpacity: new_polyline.stroke_opacity,
                 strokeWeight: new_polyline.stroke_weight,
                 path: new_polyline.path,
                 map: map_struct.map,
-                geodesic: true
+                geodesic: true,
             });
             if(new_polyline.infobox) {
                 google.maps.event.addListener(
@@ -111,15 +202,29 @@
         }
         function getInfoCallback(map_struct, content) {
             var infowindow = new google.maps.InfoWindow({content: content});
-            //infowindow.setContent(content);
-            return function(ev) {
+            return function(ev, obj = null) {
                 if (map_struct.prev_infowindow) {
                     map_struct.prev_infowindow.close();
                 }
                 map_struct.prev_infowindow = infowindow;
+                infowindow.setContent(content);
                 infowindow.setPosition(ev.latLng);
-                infowindow.open(map_struct.map, this);
+                infowindow.open(map_struct.map, obj || this);
             };
+        }
+        function initFigureMarking(map_struct) {
+            map_struct.marked_figures = [];
+            map_struct.map.addListener('zoom_changed', function() {
+                map_struct.marked_figures.map(function(el) {
+                    if (map_struct.map.getZoom() >= el.zoom) {
+                        el.marker.setVisible(false);
+                        el.figure.setVisible(true);
+                    } else {
+                        el.marker.setVisible(true);
+                        el.figure.setVisible(false);
+                    }
+                });
+            });
         }
     </script>
     {{ set_googlemaps_loaded() }}
@@ -177,31 +282,32 @@
 
         {% if gmap.cluster %}
             {{gmap.varname}}.markerCluster = new MarkerClusterer({{gmap.varname}}.map, {{gmap.varname}}.markers, {'imagePath': "{{gmap.cluster_imagepath}}", 'gridSize': {{gmap.cluster_gridsize}}});
+            {{gmap.varname}}.markerCluster.setMaxZoom({{gmap.cluster_maxzoom}});
         {% endif %}
 
         // add gmap markers
         {{ gmap.markers|tojson|safe }}.forEach(function(el) {
-            add_marker({{gmap.varname}}, el);
+            addMarker({{gmap.varname}}, el);
         });
 
         // add rectangles
         {{ gmap.rectangles|tojson|safe }}.forEach(function(el) {
-            add_rectangle({{gmap.varname}}, el);
+            addRectangle({{gmap.varname}}, el);
         });
 
         // add circles
         {{ gmap.circles|tojson|safe }}.forEach(function(el) {
-            add_circle({{gmap.varname}}, el);
+            addCircle({{gmap.varname}}, el);
         });
 
         // add polygons
         {{ gmap.polygons|tojson|safe }}.forEach(function(el) {
-            add_polygon({{gmap.varname}}, el);
+            addPolygon({{gmap.varname}}, el);
         });
 
         // add polylines
         {{ gmap.polylines|tojson|safe }}.forEach(function(el) {
-            add_polyline({{gmap.varname}}, el);
+            addPolyline({{gmap.varname}}, el);
         });
     }
     


### PR DESCRIPTION
* Refactoring in gmapjs.html reduces the size of generated html page due to functions, which are corresponding to every map, are defined once (e.g. addMarker, getInfoCallback...)
* Refactoring in gmapjs.html simplifies a user work with a generated map. Now, all of useful information is contained in a {{ gmap.varname }} javascript dictionary. For example, if you expand a behavior for a plenty of maps by a function with a "map" parameter, you don't need to send parameters like {{ gmap.varname }}_markers. Just use {{ gmap.varname }} as a parameter.
* Add a optional "user_position" option to Map. If it is true, map center will be set to user position after geolocation is accepted on browser. Thanks to [ChadKillingsworth/geolocation-marker](https://chadkillingsworth.github.io/geolocation-marker/).
* Add a optional "cluster_maxzoom" parameter to Map (default = 20). It sets a maximum zoom level where cluster marker appears.
* Add a optional "mark_zoom" parameter to figures with an area. It sets a maximum zoom level where figure is invisible. If this parameter is set and the zoom level of map is less than it, the figure is invisible and represented by a marker. It is useful when a figure is small and when you want add it to cluster.