### PR TITLE
added support for geocoding and reverse geocoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,24 @@ def map_bounded():
 
 ![image](https://user-images.githubusercontent.com/14223309/29294483-6ac3e532-8104-11e7-988c-5c19d700fe5b.png)
 
+
+### Geocoding and Reverse Geocoding 
+
+```python
+from flask_googlemaps import get_address, get_coordinates
+API_KEY = 'YOUR API KEY'
+
+#Reverse Geocoding: getting detailed address from coordinates of a location
+print(get_address(API_KEY,22.4761596,88.4149326))
+#output: {'zip': '700150', 'country': 'India', 'state': 'West Bengal', 'city': 'Kolkata', 'locality': 'Kolkata', 'road': 'Techno City', 'formatted_address': 'Sirin Rd, Mauza Ranabhutia, Techno City, Kolkata, West Bengal 700150, India'}
+
+
+#Geocoding: getting coordinates from address text
+print(get_coordinates(API_KEY,'Netaji Subhash Engineering College Kolkata'))
+#output: {'lat': 22.4761596, 'lng': 88.4149326}
+```
+
+
 ### Run the example app
 
 ```bash

--- a/flask_googlemaps/__init__.py
+++ b/flask_googlemaps/__init__.py
@@ -777,6 +777,25 @@ def set_googlemaps_loaded():
     g.googlemaps_loaded = True
     return ''
 
+def get_address(API_KEY,lat,lon):
+    add_dict = dict()
+    response = rq.get('https://maps.googleapis.com/maps/api/geocode/json?latlng='+','.join(map(str,[lat,lon]))+'&key='+API_KEY).json()
+    add_dict['zip'] = response['results'][0]['address_components'][-1]['long_name']
+    add_dict['country'] = response['results'][0]['address_components'][-2]['long_name']
+    add_dict['state'] = response['results'][0]['address_components'][-3]['long_name']
+    add_dict['city'] = response['results'][0]['address_components'][-4]['long_name']
+    add_dict['locality'] = response['results'][0]['address_components'][-5]['long_name']
+    add_dict['road'] = response['results'][0]['address_components'][-6]['long_name']
+    add_dict['formatted_address'] = response['results'][0]['formatted_address']
+    return add_dict
+    
+    
+    
+def get_coordinates( API_KEY,address_text):
+    response = rq.get('https://maps.googleapis.com/maps/api/geocode/json?address='+address_text+'&key='+API_KEY).json()
+    return response['results'][0]['geometry']['location']
+    
+
 
 def is_googlemaps_loaded():
     return getattr(g, 'googlemaps_loaded', False)


### PR DESCRIPTION
The Google Maps API provides geocoding (returns geographic coordinates for a given address) and reverse geocoding (returns well-formatted address for given geographic coordinates) features that are missing in Flask-GoogleMaps. I have created two functions (get_coordinates for geocoding and get_address for reverse geocoding) that simplify the usage of these features. I have also added examples demonstrating the use of these functions in the Readme.md file.