### PR TITLE
Fixing bug in gmapjs.html that prevents maps from displaying

### DIFF
--- a/flask_googlemaps/templates/googlemaps/gmapjs.html
+++ b/flask_googlemaps/templates/googlemaps/gmapjs.html
@@ -43,7 +43,7 @@
             streetViewControl: {% if gmap.streetview_control %}true{% else %}false{% endif %},
             rotateControl: {% if gmap.rotate_control %}true{% else %}false{% endif %},
             scrollwheel: {% if gmap.scroll_wheel %}true{% else %}false{% endif %},
-            fullscreenControl: {% if gmap.fullscreen_control %}true{% else %}false{% endif %}
+            fullscreenControl: {% if gmap.fullscreen_control %}true{% else %}false{% endif %},
             styles: {{ gmap.styles | tojson  }}
         });
 


### PR DESCRIPTION
A typo in gmapjs.html prevented maps for rendering properly as it breaks the JS